### PR TITLE
Fixed bug in ngOnDestroy

### DIFF
--- a/webcam.component.js
+++ b/webcam.component.js
@@ -224,7 +224,7 @@ var WebCamComponent = (function () {
     };
     WebCamComponent.prototype.ngOnDestroy = function () {
         this.observer.disconnect();
-        window.removeEventListener(this.onResize);
+        window.removeEventListener('resize', this.onResize);
         var vid = this.getVideoElm();
         if (vid && vid.pause) {
             vid.pause();


### PR DESCRIPTION
Was throwing "ERROR TypeError: Failed to execute 'removeEventListener' on 'EventTarget': 2 arguments required, but only 1 present."