### PR TITLE
Add ability to set ideal width and height on media

### DIFF
--- a/src/videoHelp.ts
+++ b/src/videoHelp.ts
@@ -20,6 +20,7 @@ export interface Options {
   fallbackSrc: string
   fallbackMode: string
   fallbackQuality: number
+  videoOptions: MediaTrackConstraints
 }
 
 export interface VideoObject{

--- a/src/webcam.component.ts
+++ b/src/webcam.component.ts
@@ -178,7 +178,7 @@ export interface vidElmOptions{
 
   promiseVideoOptions():Promise<MediaTrackConstraints>{
     let promise = Promise.resolve()
-    const videoOptions:MediaTrackConstraints = { width: { ideal: this.idealVideoWidth }, height: { ideal: this.idealVideoHeight } }
+    const videoOptions:MediaTrackConstraints = this.options.videoOptions || {}
 
     if( this.facingMode ){
       videoOptions.facingMode = this.facingMode//{exact:this.facingMode}

--- a/src/webcam.component.ts
+++ b/src/webcam.component.ts
@@ -39,6 +39,8 @@ export interface vidElmOptions{
   @Input() videoDevice:MediaDeviceInfo
   @Input() videoDeviceId:string
   //@Input() audioDeviceId:string
+  @Input() idealVideoWidth = 640
+  @Input() idealVideoHeight = 480
   
   @Input() reflect:boolean
   @Input() facingMode:"user"|"environment"|"left"|"right"|string
@@ -176,7 +178,7 @@ export interface vidElmOptions{
 
   promiseVideoOptions():Promise<MediaTrackConstraints>{
     let promise = Promise.resolve()
-    const videoOptions:MediaTrackConstraints = {}
+    const videoOptions:MediaTrackConstraints = { width: { ideal: this.idealVideoWidth }, height: { ideal: this.idealVideoHeight } }
 
     if( this.facingMode ){
       videoOptions.facingMode = this.facingMode//{exact:this.facingMode}


### PR DESCRIPTION
When getting MediaTracks it's possible to set "min", "max", "exact" or "ideal" dimentions.
Setting "ideal" dimentions won't break source but lets the developer adjust the video size.